### PR TITLE
Fix 'resources' directory location

### DIFF
--- a/src/resources/ResourcesManager.cpp
+++ b/src/resources/ResourcesManager.cpp
@@ -15,7 +15,7 @@
 
 /// Singleton.
 Resources& Resources::manager(){
-	static Resources* res = new Resources("../../../resources");
+	static Resources* res = new Resources("../../resources");
 	return *res;
 }
 


### PR DESCRIPTION
Changes resources directory location to reflect the default location.
Fix originally identified by Mysteli